### PR TITLE
fix: update tracked entities API call

### DIFF
--- a/src/api/data.js
+++ b/src/api/data.js
@@ -4,8 +4,8 @@ import useMetadataStore from "@/states/metadata";
 const { ATTRIBUTE_CODE } = TRACKED_ENTITY_ATTRIBUTES;
 
 const getFacilityTeis = async (orgUnit) => {
-  const result = await pull(`/api/tracker/trackedEntities?program=dJELklAE1ZZ&orgUnit=${orgUnit}&ouMode=ACCESSIBLE&fields=*&skipPaging=true`);
-  return result.instances;
+  const result = await pull(`/api/tracker/trackedEntities?program=dJELklAE1ZZ&orgUnit=${orgUnit}&fields=*&skipPaging=true`);
+  return result.instances ?? [];
 };
 
 const getTeiById = async (teiId) => {


### PR DESCRIPTION
Fixes two issues I encountered:

1. The call to `/trackedEntities` returns 400 `orgUnitMode ACCESSIBLE cannot be used with orgUnits. Please remove the orgUnit parameter and try again` so this PR removes  `orgUnitMode=ACCESSIBLE` part.
2. result.instances is `undefined` just after setup, so should fall back to [] otherwise the UI fails

I am not sure if the first change is what is intended, but the second one is necessary to make the consumer of that `getFacilityTeis` safe.