### PR TITLE
fix: ensure program's metadata (not data) is viewable

### DIFF
--- a/src/assets/metadata-backup.json
+++ b/src/assets/metadata-backup.json
@@ -14,7 +14,7 @@
           "shYXBFb3lpw": { "displayName": "FCA - Synchronization", "access": "r-rw----", "id": "shYXBFb3lpw" },
           "xd865kZFSRw": { "displayName": "FCA - Approval", "access": "r-rw----", "id": "xd865kZFSRw" }
         },
-        "public": "--------"
+        "public": "r-------"
       },
       "shortName": "FC:Facility checker",
       "version": 14,

--- a/src/assets/metadata.json
+++ b/src/assets/metadata.json
@@ -51,7 +51,7 @@
           "shYXBFb3lpw": { "displayName": "FCA - Synchronization", "access": "r-rw----", "id": "shYXBFb3lpw" },
           "xd865kZFSRw": { "displayName": "FCA - Approval", "access": "r-rw----", "id": "xd865kZFSRw" }
         },
-        "public": "--------"
+        "public": "r-------"
       },
       "shortName": "FC:Facility checker",
       "version": 14,


### PR DESCRIPTION
I think this fixes the issue with users not getting to the right screen, even though they FCA_CAPTURE authority.